### PR TITLE
allow statements in object form {text,parameters}

### DIFF
--- a/lib/ogmneo-cypher.js
+++ b/lib/ogmneo-cypher.js
@@ -23,7 +23,7 @@ class OGMNeoCypher {
             } else {
                 let session = OGMNeo.session();
                 let readTxResultPromise = session.readTransaction((transaction) => {
-                    if (_.isString(statements)) {
+                    if (isStatement(statements)) {
                         return transaction.run(statements);
                     } else {
                         return Promise.all(statements.map(statement => transaction.run(statement)));
@@ -55,7 +55,7 @@ class OGMNeoCypher {
             } else {
                 let session = OGMNeo.session();
                 let writeTxResultPromise = session.writeTransaction((transaction) => {
-                    if (_.isString(statements)) {
+                    if (isStatement(statements)) {
                         return transaction.run(statements);
                     } else {
                         return Promise.all(statements.map(statement => transaction.run(statement)));
@@ -73,12 +73,15 @@ class OGMNeoCypher {
     }
 }
 
+function isStatement(s) {
+    return _.isString(s) || s.hasOwnProperty('text');
+}
 //Private validate statements
 function _validateStatements(statements) {
-    if (_.isString(statements)) {
+    if (isStatement(statements)) {
         return true;
     } else if (_.isArray(statements)) {
-        let filtered = statements.filter(statement => _.isString(statement));
+        let filtered = statements.filter(statement => isStatement(statement));
         return !_.isEmpty(filtered);
     }
     return false;


### PR DESCRIPTION
The neo4j-driver library allows to run statements in object form, with parameter placeholders (https://neo4j.com/docs/api/javascript-driver/current/class/src/v1/session.js~Session.html#instance-method-run). That should be the preferred way instead of string concatenation to prevent possibility of code injection in the queries.